### PR TITLE
Fix bug in computation of the magnetization vector

### DIFF
--- a/notebooks/functions/ellipsoid_magnetics.py
+++ b/notebooks/functions/ellipsoid_magnetics.py
@@ -65,8 +65,9 @@ def ellipsoid_magnetics(
         anisotropic susceptibility.
 
     external_field : ndarray
-        The uniform magnetic field as and array with values of
-        (magnitude, inclination, declination).
+        The uniform magnetic field (B) as and array with values of
+        (magnitude, inclination, declination). The magnitude should be in nT, and the
+        angles in degrees.
 
     field : (optional) str, one of either "e", "n", "u".
         if no input is given, the function will return all three components of

--- a/notebooks/functions/ellipsoid_magnetics.py
+++ b/notebooks/functions/ellipsoid_magnetics.py
@@ -187,32 +187,45 @@ def ellipsoid_magnetics(
 
 
 def _get_magnetisation(a, b, c, k, h0):
-    """
+    r"""
     Get the magnetization vector from the ellipsoid parameters and the rotated
     external field.
 
-    parameters
+    Parameters
     ----------
     a, b, c : floats
-        Semiaxis lengths of the ellipsoid.
-
-    k: float, matrix
-        Susceptabiity value/s (float for isotropic or matrix for anisotropic)
-
+        Semi-axes lengths of the ellipsoid.
+    k : (3, 3) array
+        Susceptibility tensor.
     h0: array
-        the rotated background field (local coordinates).
+        The rotated background field (in local coordinates).
 
-    returns
+    Returns
     -------
     m (magentisation): array
-        the magnetisation vector for the define body.
+        The magnetisation vector for the defined body.
 
+    Notes
+    -----
+    Considering an ellipsoid with susceptibility :math:`\chi` (scalar or tensor) in
+    a uniform background field :math:`\mathbf{H}_0`, compute the magnetization vector
+    :math:`\mathbf{M}` of the ellipsoid accounting for demagnetization effects as:
+
+    .. math::
+
+        \mathbf{M} =
+        \chi \[left \mathbf{I} + \mathbf{N}^\text{int} \chi \right]^{-1} \mathbf{H}_0,
+
+    where :math:`\mathbf{N}^\text{int}` is the internal demagnetization tensor, defined
+    as:
+
+    .. math::
+
+        \mathbf{H}(\mathbf{r}) = \mathbf{H}_0 - \mathbf{N}(\mathbf{r}) \mathbf{M}.
     """
-
     n_cross = _construct_n_matrix_internal(a, b, c)
-    inv = np.linalg.inv(np.identity(3) - (n_cross @ k))
+    inv = np.linalg.inv(np.identity(3) + (n_cross @ k))
     m = k @ inv @ h0
-
     return m
 
 

--- a/notebooks/functions/test_magnetics_ellipsoids.py
+++ b/notebooks/functions/test_magnetics_ellipsoids.py
@@ -385,10 +385,14 @@ class TestDemagnetizationEffects:
         a, b, c = ellipsoid_semiaxes
         susceptibility = 0.5
         susceptibility_tensor = susceptibility * np.identity(3)
+
+        # Compute magnetization considering demagnetization effect
         magnetization = _get_magnetisation(a, b, c, susceptibility_tensor, h0_field)
+
+        # Compute magnetization without considering demagnetization effect
         magnetization_no_demag = susceptibility * h0_field
 
-        # Check
+        # Check that the former is smaller than the latter
         assert (magnetization**2).sum() < (magnetization_no_demag**2).sum()
 
 

--- a/notebooks/functions/utils_ellipsoids.py
+++ b/notebooks/functions/utils_ellipsoids.py
@@ -254,3 +254,32 @@ def _sphere_magnetic(coordinates, radius, center, magnetization):
 
     be, bn, bu = tuple(b.reshape(cast.shape) for b in (be, bn, bu))
     return be, bn, bu
+
+
+def _get_sphere_magnetization(susceptibility, external_field):
+    """
+    Compute sphere's induced magnetization.
+
+    Parameters
+    ----------
+    susceptibility : float or (3, 3) array
+        Magnetic susceptibility of the sphere as a scalar or a tensor.
+    external_field : tuple
+        The uniform magnetic field B as a tuple with values of
+        (magnitude, inclination, declination). The magnitude should be in nT.
+
+    Returns
+    -------
+    magnetization : tuple
+        Tuple with components of the magnetization vector in A/m.
+    """
+    # Get external field components
+    b0_field = np.array(hm.magnetic_angles_to_vec(*external_field))
+    h0_field = b0_field / mu_0 * 1e-9  # convert to T
+
+    # Compute magnetization of the sphere accounting for demagnetization effect.
+    if not isinstance(susceptibility, np.ndarray):
+        susceptibility = susceptibility * np.identity(3)
+    inv = np.linalg.inv(np.identity(3) + 1 / 3 * susceptibility)
+    magnetization = susceptibility @ inv @ h0_field
+    return magnetization


### PR DESCRIPTION
Fix bug in the `_get_magnetisation` function related to a wrong sign when computing the magnetization vector of an ellipsoid considering the demagnetization effect. Add tests for checking that the magnetization considering demagnetization effect is smaller than the magnetization without considering it, and to check that the components of the internal demagnetization tensor are all positive.

Fixes #59
