### PR TITLE
Fix bug in `ellipsoid_gravity.py`

### DIFF
--- a/notebooks/functions/ellipsoid_gravity.py
+++ b/notebooks/functions/ellipsoid_gravity.py
@@ -143,7 +143,7 @@ def ellipsoid_gravity(coordinates, ellipsoids, density, field="g"):
         gn += gn_i
         gu += gu_i
 
-        return {"e": ge, "n": gn, "u": gu}.get(field, (ge, gn, gu))
+    return {"e": ge, "n": gn, "u": gu}.get(field, (ge, gn, gu))
 
 
 def _get_abc(a, b, c, lmbda):


### PR DESCRIPTION
Fix wrong indentation of return statement, which made the function to return only the fields of the first ellipsoid in the list.
